### PR TITLE
Support for showing/hiding tabs by user level, fixed setting window dimensions

### DIFF
--- a/src/app/LoginController.java
+++ b/src/app/LoginController.java
@@ -128,7 +128,7 @@ public class LoginController implements Initializable {
          boolean isLoggedIn = account != null && account.validatePassword(password.getText());
          if (isLoggedIn) {
             timer.cancel();
-            ViewManager.getManager().setCurrentAccount(account);
+            ViewManager.getManager().loginAccount(account);
             ViewManager.getManager().navigate("TabView");
          } else {
             errorLabel.setVisible(true);

--- a/src/app/LoginController.java
+++ b/src/app/LoginController.java
@@ -128,6 +128,7 @@ public class LoginController implements Initializable {
          boolean isLoggedIn = account != null && account.validatePassword(password.getText());
          if (isLoggedIn) {
             timer.cancel();
+            ViewManager.getManager().setCurrentAccount(account);
             ViewManager.getManager().navigate("TabView");
          } else {
             errorLabel.setVisible(true);

--- a/src/app/TabView.fxml
+++ b/src/app/TabView.fxml
@@ -7,10 +7,9 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.StackPane?>
 
-
 <StackPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="app.TabViewController">
     <children>
-        <TabPane prefHeight="200.0" prefWidth="200.0" tabClosingPolicy="UNAVAILABLE">
+        <TabPane fx:id="tabPane" prefHeight="200.0" prefWidth="200.0" tabClosingPolicy="UNAVAILABLE">
             <tabs>
                 <Tab fx:id="homeTab" text="Home">
                     <content>

--- a/src/app/TabViewController.java
+++ b/src/app/TabViewController.java
@@ -11,6 +11,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
 
 /**
  * TabViewController is the controller for the TabView, the view top-level
@@ -21,6 +22,9 @@ public class TabViewController implements Initializable {
 
    @FXML
    private Label clockLabel;
+
+   @FXML
+   private TabPane tabPane;
 
    @FXML
    private Tab homeTab;
@@ -63,7 +67,25 @@ public class TabViewController implements Initializable {
 
    @Override
    public void initialize(URL url, ResourceBundle rb) {
+      setTabs();
       startClock();
+
+   }
+
+   /**
+    * Tests employee level and sets the tab pane to show associated tabs
+    */
+   private void setTabs() {
+      tabPane.getTabs().clear();
+      
+      if (ViewManager.getManager().isEmployeeAccountLoggedIn()) {
+         // nurse view
+         tabPane.getTabs().addAll(homeTab, patientListTab, updateStatusTab, admittingTab);
+      } else {
+         // patient view
+         // TODO add the complete set of tabs here once the patient-related views have been created
+         tabPane.getTabs().addAll(homeTab);
+      }
    }
 
 }

--- a/src/app/ViewManager.java
+++ b/src/app/ViewManager.java
@@ -113,9 +113,17 @@ public class ViewManager {
     * Sets the account currently logged in
     * @param currentAccount 
     */
-   public void setCurrentAccount(Account currentAccount) {
+   public void loginAccount(Account currentAccount) {
       ViewManager.currentAccount = currentAccount;
       System.out.printf("Logged in account %s%n", currentAccount.getLoginName());
+   }
+   
+   /**
+    * Logs out the current account, if set
+    */
+   public void logoutAccount() {      
+      System.out.printf("Logged out current account%n", currentAccount.getLoginName());
+      ViewManager.currentAccount = null;
    }
 
    /**

--- a/src/app/ViewManager.java
+++ b/src/app/ViewManager.java
@@ -1,12 +1,12 @@
 package app;
 
+import hospital.Account;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.ScrollPane;
 import javafx.stage.Stage;
 
 /**
@@ -15,10 +15,10 @@ import javafx.stage.Stage;
  */
 public class ViewManager {
 
-   private ScrollPane injectorControl;
    private static ViewManager instance;
    private Stage stage;
    private int x, y;
+   private static Account currentAccount = null;
 
    private final static int DEFAULT_WIDTH = 640;
    private final static int DEFAULT_HEIGHT = 500;
@@ -107,4 +107,22 @@ public class ViewManager {
       return instance;
    }
 
+   /**
+    * Sets the account currently logged in
+    * @param currentAccount 
+    */
+   public void setCurrentAccount(Account currentAccount) {
+      ViewManager.currentAccount = currentAccount;
+      System.out.printf("Logged in account %s%n", currentAccount.getLoginName());
+   }
+
+   /**
+    * Tests the currently logged in account (if any) for employee status
+    *
+    * @return true if the current account is an employee, false otherwise or if
+    * no account is logged in
+    */
+   public boolean isEmployeeAccountLoggedIn() {
+      return (ViewManager.currentAccount != null && ViewManager.currentAccount.isEmployee());
+   }
 }

--- a/src/app/ViewManager.java
+++ b/src/app/ViewManager.java
@@ -57,6 +57,8 @@ public class ViewManager {
    public void setDimensions(int x, int y) {
       this.x = x;
       this.y = y;
+      stage.setWidth(x);
+      stage.setHeight(y);
    }
 
    public int getX() {

--- a/src/app/ViewManager.java
+++ b/src/app/ViewManager.java
@@ -111,19 +111,22 @@ public class ViewManager {
 
    /**
     * Sets the account currently logged in
-    * @param currentAccount 
+    *
+    * @param currentAccount
     */
    public void loginAccount(Account currentAccount) {
       ViewManager.currentAccount = currentAccount;
       System.out.printf("Logged in account %s%n", currentAccount.getLoginName());
    }
-   
+
    /**
     * Logs out the current account, if set
     */
-   public void logoutAccount() {      
-      System.out.printf("Logged out current account%n", currentAccount.getLoginName());
-      ViewManager.currentAccount = null;
+   public void logoutAccount() {
+      if (ViewManager.currentAccount != null) {
+         System.out.printf("Logged out current account%n", currentAccount.getLoginName());
+         ViewManager.currentAccount = null;
+      }
    }
 
    /**


### PR DESCRIPTION
This PR has three main changes:

1. ViewManager keeps track of the currently-logged-in account and provides a method to get the user level (employee or not employee).

2. TabViewController tests the user's level and shows only those appropriate tabs.
Note: the only tab shown to patients right now is "Home" as we haven't created the others yet. 

3. ViewManager wasn't updating the stage window dimensions when its setDimensions method was called. That's now fixed.